### PR TITLE
ACM Certificate

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -120,6 +120,11 @@ app_domain_name:
     type: str
     help: What is the domain name for the application (e.g. app.initech.com)?
 
+attach_acm_cert_to_cloudfront:
+    type: bool
+    help: Has the ACM Certificate been fully validated and is ready to attach to the Cloudfront domain?
+    default: no
+
 # Additional Settings
 _min_copier_version: "9.4"
 

--- a/template/infrastructure/src/infrastructure/jinja_constants.py.jinja
+++ b/template/infrastructure/src/infrastructure/jinja_constants.py.jinja
@@ -1,2 +1,3 @@
 {% raw %}APP_DOMAIN_NAME = "{% endraw %}{{ app_domain_name }}{% raw %}"
-APP_DIRECTORY_NAME = "{% endraw %}{{ app_name }}{% raw %}_app"{% endraw %}
+APP_DIRECTORY_NAME = "{% endraw %}{{ app_name }}{% raw %}_app"
+ATTACH_ACM_CERT_TO_CLOUDFRONT = {% endraw %}{{ 'True' if attach_acm_cert_to_cloudfront else 'False' }}{% raw %}

--- a/template/infrastructure/src/infrastructure/jinja_constants.py.jinja
+++ b/template/infrastructure/src/infrastructure/jinja_constants.py.jinja
@@ -1,3 +1,3 @@
 {% raw %}APP_DOMAIN_NAME = "{% endraw %}{{ app_domain_name }}{% raw %}"
 APP_DIRECTORY_NAME = "{% endraw %}{{ app_name }}{% raw %}_app"
-ATTACH_ACM_CERT_TO_CLOUDFRONT = {% endraw %}{{ 'True' if attach_acm_cert_to_cloudfront else 'False' }}{% raw %}
+ATTACH_ACM_CERT_TO_CLOUDFRONT = {% endraw %}{{ 'True' if attach_acm_cert_to_cloudfront else 'False' }}{% raw %}{% endraw %}

--- a/template/infrastructure/src/infrastructure/program.py
+++ b/template/infrastructure/src/infrastructure/program.py
@@ -1,11 +1,13 @@
+import hashlib
 import logging
 import mimetypes
 import os
+from collections.abc import Sequence
 from pathlib import Path
-from uuid import uuid4
 
 import pulumi
 from ephemeral_pulumi_deploy import append_resource_suffix
+from ephemeral_pulumi_deploy import common_tags
 from ephemeral_pulumi_deploy import common_tags_native
 from ephemeral_pulumi_deploy import get_aws_account_id
 from ephemeral_pulumi_deploy import get_config_str
@@ -14,6 +16,8 @@ from pulumi import Output
 from pulumi import Resource
 from pulumi import ResourceOptions
 from pulumi import export
+from pulumi_aws.acm import Certificate
+from pulumi_aws.acm.outputs import CertificateDomainValidationOption
 from pulumi_aws.iam import GetPolicyDocumentStatementArgs
 from pulumi_aws.iam import GetPolicyDocumentStatementPrincipalArgs
 from pulumi_aws.iam import get_policy_document
@@ -24,6 +28,9 @@ from pulumi_command.local import Command
 
 from .jinja_constants import APP_DIRECTORY_NAME
 from .jinja_constants import APP_DOMAIN_NAME
+from .jinja_constants import ATTACH_ACM_CERT_TO_CLOUDFRONT
+
+RAW_DOMAIN_NAME = APP_DOMAIN_NAME.removeprefix("www.")
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +40,26 @@ repo_root = Path(__file__).parent.parent.parent.parent
 def _get_mime_type(file_path: Path) -> str:
     content_type, _ = mimetypes.guess_type(file_path)
     return content_type or "application/octet-stream"
+
+
+def _compute_directory_hash(base_dir: Path) -> str:
+    """Compute a hash of all files in a directory based on their paths, sizes, and modification times."""
+    hash_md5 = hashlib.md5()  # noqa: S324 # we don't care about security here, just if files have changed for creating the invalidation
+
+    for dirpath, _, filenames in sorted(os.walk(base_dir)):
+        for filename in sorted(filenames):
+            file_path = Path(dirpath) / filename
+            rel_path = os.path.relpath(file_path, base_dir)
+
+            # Hash the relative path
+            hash_md5.update(rel_path.encode())
+
+            # Hash file size and mtime
+            stat = file_path.stat()
+            hash_md5.update(str(stat.st_size).encode())
+            hash_md5.update(str(stat.st_mtime).encode())
+
+    return hash_md5.hexdigest()
 
 
 def _upload_assets_to_s3(*, bucket_id: Output[str], base_dir: Path) -> list[Resource]:
@@ -101,17 +128,32 @@ def pulumi_program() -> None:
         bucket=app_website_bucket.bucket_name,  # pyright: ignore[reportArgumentType] # it doesn't seem like it's possible for the bucket name to actually be Output[None]...not sure why the typing suggests that...and not sure a way to assert about Output subtypes
         policy_document=policy_json,
     )
+    static_files_dir = repo_root / APP_DIRECTORY_NAME / ".output" / "public"
 
-    all_uploads = _upload_assets_to_s3(
-        bucket_id=app_website_bucket.id, base_dir=repo_root / APP_DIRECTORY_NAME / ".output" / "public"
-    )
+    all_uploads = _upload_assets_to_s3(bucket_id=app_website_bucket.id, base_dir=static_files_dir)
     if env in PROTECTED_ENVS:
+        certificate = Certificate(
+            append_resource_suffix("certificate"),
+            domain_name=f"*.{RAW_DOMAIN_NAME}",
+            validation_method="DNS",
+            region="us-east-1",
+            tags=common_tags(),
+        )
         origin_id = "S3OriginMyBucket"
         origin_domain = app_website_bucket.website_url.apply(lambda full_url: full_url.removeprefix("http://"))
+        viewer_certificate = cloudfront.DistributionViewerCertificateArgs(cloud_front_default_certificate=True)
+        if ATTACH_ACM_CERT_TO_CLOUDFRONT:
+            viewer_certificate = cloudfront.DistributionViewerCertificateArgs(  # TODO: determine if this needs to be attached to EVERY distribution, or just a single distribution unrelated to the actual bucket
+                acm_certificate_arn=certificate.arn,
+                ssl_support_method="sni-only",
+                minimum_protocol_version="TLSv1.2_2021",
+            )
         app_cloudfront = cloudfront.Distribution(
             append_resource_suffix("app"),
             distribution_config=cloudfront.DistributionConfigArgs(
+                aliases=[APP_DOMAIN_NAME],
                 price_class="PriceClass_100",
+                comment=f"{RAW_DOMAIN_NAME} App CloudFront Distribution",
                 origins=[
                     cloudfront.DistributionOriginArgs(
                         domain_name=origin_domain,
@@ -139,7 +181,7 @@ def pulumi_program() -> None:
                 restrictions=cloudfront.DistributionRestrictionsArgs(
                     geo_restriction=cloudfront.DistributionGeoRestrictionArgs(restriction_type="none")
                 ),
-                viewer_certificate=cloudfront.DistributionViewerCertificateArgs(cloud_front_default_certificate=True),
+                viewer_certificate=viewer_certificate,
             ),
             tags=common_tags_native(),
         )
@@ -148,7 +190,16 @@ def pulumi_program() -> None:
         _ = Command(
             append_resource_suffix("app-cloudfront-invalidation"),
             create=app_cloudfront.id.apply(
-                lambda distribution_id: f'aws cloudfront create-invalidation --distribution-id {distribution_id} --paths "/*" && echo {uuid4()}'
+                lambda distribution_id: f'aws cloudfront create-invalidation --distribution-id {distribution_id} --paths "/*" && echo {_compute_directory_hash(static_files_dir)}'
             ),
             opts=ResourceOptions(depends_on=all_uploads),
         )
+
+        def _extract_host(options: Sequence[CertificateDomainValidationOption]) -> str:
+            record_name = options[0].resource_record_name
+            assert record_name is not None
+            return record_name.removesuffix(f".{RAW_DOMAIN_NAME}.")
+
+        cname_host = certificate.domain_validation_options.apply(_extract_host)
+        export("certificate-cname-host", cname_host)
+        export("certificate-cname-value", certificate.domain_validation_options[0].resource_record_value)

--- a/tests/copier_data/data1.yaml
+++ b/tests/copier_data/data1.yaml
@@ -19,3 +19,4 @@ aws_region_for_stack: us-east-2
 app_name: my_app
 has_backend: true
 app_domain_name: myapp.great-company.com
+attach_acm_cert_to_cloudfront: true

--- a/tests/copier_data/data2.yaml
+++ b/tests/copier_data/data2.yaml
@@ -24,3 +24,4 @@ aws_region_for_stack: us-west-1
 app_name: foobar
 has_backend: false
 app_domain_name: foobar.initech.com
+attach_acm_cert_to_cloudfront: false


### PR DESCRIPTION
 ## Why is this change necessary?
Need to attach one to cloudfront for SSL


 ## How does this change address the issue?
Adds one, and a question about if it's been validated and ready to attach


 ## What side effects does this change have?
N/A


 ## How is this change tested?
Downstream repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional setting to mark an ACM certificate as ready to attach to a CloudFront domain.
  * Automatic ACM certificate provisioning for protected environments with DNS validation.

* **Improvements**
  * CloudFront distributions now support domain aliases and conditional certificate attachment.
  * Cache invalidation for static assets uses content-based hashing for more accurate invalidation.

* **Tests**
  * Test configurations updated to include the new ACM attachment option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->